### PR TITLE
Create docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM scanomatic/scanner
+COPY src/scanimage /usr/bin/
+COPY src/data /srv/scans
+ENV FAKE_SCANIMAGE_DATA=/srv/scans

--- a/src/scanimage
+++ b/src/scanimage
@@ -71,7 +71,9 @@ def scan():
 if __name__ == "__main__":
     flag = sys.argv[1] if len(sys.argv) > 1 else ''
     if flag == '-V':
-        print("scanimage (sane-backends) 1.0.27; backend version 1.0.27")
+        print(
+            "scanimage (sane-backends) 1.0.27; backend version 1.0.27 (fake)"
+        )
     elif flag == '-L':
         print(
             "device `epson2:libusb:001:083' is a Epson GT-X980 flatbed scanner"

--- a/src/scanimage
+++ b/src/scanimage
@@ -1,11 +1,25 @@
 #!/usr/bin/env python3
-import json
 from datetime import datetime, date
+from glob import glob
+import json
 import os
 import sys
-from glob import glob
 
 _DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+
+def get_history_file():
+    return os.getenv(
+        'FAKE_SCANIMAGE_HISTORY',
+        '/tmp/fake_scanimage_history.json',
+    )
+
+
+def get_data_directory():
+    return os.getenv(
+        'FAKE_SCANIMAGE_DATA',
+        os.path.join(os.path.dirname(__file__), 'data'),
+    )
 
 
 def _json_serial(obj):
@@ -18,9 +32,7 @@ def _json_serial(obj):
 
 def get_stored_history():
     try:
-        with open(os.environ.get(
-            'FAKE_SCANIMAGE_HISTORY', 'fake_scanimage_history.json'
-        ), 'r') as fh:
+        with open(get_history_file()) as fh:
             data = json.load(fh)
     except (OSError, json.decoder.JSONDecodeError):
         data = {'scans': []}
@@ -32,12 +44,8 @@ def get_stored_history():
 
 
 def dump_history(history):
-    path = os.environ.get(
-        'FAKE_SCANIMAGE_HISTORY', 'fake_scanimage_history.json'
-    )
-    with open(path, 'w') as fh:
+    with open(get_history_file(), 'w') as fh:
         json.dump(history, fh, default=_json_serial)
-    return path
 
 
 def is_in_sequence(history, image_paths):
@@ -53,7 +61,7 @@ def is_in_sequence(history, image_paths):
 
 
 def get_scans():
-    return sorted(glob(os.path.join(os.path.dirname(__file__), 'data/*.tiff')))
+    return sorted(glob(os.path.join(get_data_directory(), '*.tiff')))
 
 
 def scan():

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -13,8 +13,8 @@ def test_storing_and_then_loading_history(scanimage, history_file):
     assert history == {'scans': []}
     dt = datetime(1990, 10, 15, 8, 13)
     history['scans'].append(dt)
-    path = scanimage.dump_history(history)
-    with open(path, 'rb') as fh:
+    scanimage.dump_history(history)
+    with open(history_file.name, 'rb') as fh:
         assert (
             fh.read().decode() == '{"scans": ["1990-10-15T08:13:00.000000Z"]}'
         )

--- a/tox.ini
+++ b/tox.ini
@@ -7,13 +7,9 @@ deps =
     pytest
     pytest-cov
     freezegun
-whitelist_externals =
-    chromedriver
-passenv =
-    DISPLAY
 commands =
     pytest \
-        --cov src --cov-report xml \
+        --cov src --cov-report xml --cov-branch \
         --junitxml result.xml --ignore dev \
         --capture=fd \
         {posargs}


### PR DESCRIPTION
* Create a new docker image where the fake `scanimage` script is used.
* Better default: put the history file in `/tmp`
* Add an environment variable to set the location of the images

Note: `scanomatic/scanner` is an automated docker build of the scan-o-matic/scanomatic-scanner repository.
